### PR TITLE
[Feature] 공통컴포넌트작업(포스터박스, 스켈레톤)

### DIFF
--- a/src/components/CommonUI/PosterBox/PosterBox.styled.ts
+++ b/src/components/CommonUI/PosterBox/PosterBox.styled.ts
@@ -1,0 +1,32 @@
+import {
+  ContentBoxProps,
+  MovieImageBoxProps,
+  PosterBoxContainerProps
+} from '@/types/components'
+import styled from 'styled-components'
+
+export const PosterBoxContainer = styled.div<PosterBoxContainerProps>`
+  width: ${props => (props.flex ? '100%' : '212px')};
+  display: ${props => (props.flex ? 'flex' : 'inline-block')};
+  margin: var(--space-small);
+`
+export const MovieImageBox = styled.img<MovieImageBoxProps>`
+  width: ${props => (props.flex ? '100px' : '212px')};
+  height: ${props => (props.flex ? '150px' : '318px')};
+  border-radius: var(--border-radius-small);
+`
+export const ContentBox = styled.div<ContentBoxProps>`
+  ${props => (props.flex ? 'align-self: center' : '')};
+  ${props => (props.flex ? 'margin-left: var(--space-medium)' : '')};
+`
+export const ContentTitle = styled.div`
+  font-size: var(--font-medium);
+  border-radius: var(--border-radius-small);
+  margin-top: var(--space-medium);
+`
+export const ContentDescription = styled.div`
+  font-size: 0.75rem;
+  color: var(--color-text-gray);
+  border-radius: var(--border-radius-small);
+  margin-top: var(--space-medium);
+`

--- a/src/components/CommonUI/PosterBox/PosterBox.styled.ts
+++ b/src/components/CommonUI/PosterBox/PosterBox.styled.ts
@@ -25,7 +25,7 @@ export const ContentTitle = styled.div`
   margin-top: var(--space-medium);
 `
 export const ContentDescription = styled.div`
-  font-size: 0.75rem;
+  font-size: var(--font-small);
   color: var(--color-text-gray);
   border-radius: var(--border-radius-small);
   margin-top: var(--space-medium);

--- a/src/components/CommonUI/PosterBox/PosterBox.tsx
+++ b/src/components/CommonUI/PosterBox/PosterBox.tsx
@@ -1,0 +1,35 @@
+import { PosterBoxProps } from '@/types/components'
+import {
+  ContentBox,
+  ContentDescription,
+  ContentTitle,
+  MovieImageBox,
+  PosterBoxContainer
+} from './PosterBox.styled'
+
+export const PosterBox = ({
+  title,
+  imageUrl,
+  date,
+  flex,
+  onClick
+}: PosterBoxProps) => {
+  return (
+    <PosterBoxContainer
+      title={title}
+      imageUrl={imageUrl}
+      date={date}
+      flex={flex}
+      onClick={onClick}>
+      <MovieImageBox
+        src={imageUrl}
+        alt={title}
+        flex={flex}
+      />
+      <ContentBox flex={flex}>
+        <ContentTitle>{title}</ContentTitle>
+        <ContentDescription>{date}</ContentDescription>
+      </ContentBox>
+    </PosterBoxContainer>
+  )
+}

--- a/src/components/CommonUI/PosterBox/PosterBox.tsx
+++ b/src/components/CommonUI/PosterBox/PosterBox.tsx
@@ -6,14 +6,33 @@ import {
   MovieImageBox,
   PosterBoxContainer
 } from './PosterBox.styled'
+import {
+  SkeletonContainer,
+  SkeletonContentBox,
+  SkeletonDescription,
+  SkeletonImage,
+  SkeletonTitle
+} from '../Skeleton/Skeleton'
 
 export const PosterBox = ({
   title,
   imageUrl,
   date,
   flex,
-  onClick
+  onClick,
+  isLoading
 }: PosterBoxProps) => {
+  if (isLoading) {
+    return (
+      <SkeletonContainer flex={flex}>
+        <SkeletonImage flex={flex} />
+        <SkeletonContentBox flex={flex}>
+          <SkeletonTitle />
+          <SkeletonDescription />
+        </SkeletonContentBox>
+      </SkeletonContainer>
+    )
+  }
   return (
     <PosterBoxContainer
       title={title}

--- a/src/components/CommonUI/Skeleton/Skeleton.tsx
+++ b/src/components/CommonUI/Skeleton/Skeleton.tsx
@@ -1,0 +1,64 @@
+import styled, { keyframes } from 'styled-components'
+
+const loading = keyframes`
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+`
+
+export const SkeletonBox = styled.div<{ flex?: boolean }>`
+  background: linear-gradient(
+    90deg,
+    var(--color-light-gray),
+    var(--color-gray)
+  );
+  background-size: 200% 100%;
+  animation: ${loading} 1.5s infinite;
+  border-radius: var(--border-radius-small);
+`
+
+export const SkeletonContainer = styled(SkeletonBox)`
+  ${props => (props.flex ? 'height:150px;' : '')}
+  width: ${props => (props.flex ? '100%' : '212px')};
+  display: ${props => (props.flex ? 'flex' : 'inline-block')};
+  margin: var(--space-small);
+  background: none;
+`
+
+export const SkeletonImage = styled(SkeletonBox)`
+  width: ${props => (props.flex ? '100px' : '212px')};
+  height: ${props => (props.flex ? '150px' : '318px')};
+`
+
+export const SkeletonContentBox = styled.div<{ flex?: boolean }>`
+  ${props => (props.flex ? 'align-self: center' : '')};
+  ${props => (props.flex ? 'margin-left: var(--space-medium)' : '')};
+  width: ${props => (props.flex ? '60%' : '100%')};
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-small);
+`
+
+export const SkeletonTitle = styled(SkeletonBox)`
+  width: ${props => (props.flex ? '60%' : '100%')};
+  height: 1.25rem;
+  margin-top: var(--space-small);
+`
+
+export const SkeletonDescription = styled(SkeletonBox)`
+  width: ${props => (props.flex ? '40%' : '100%')};
+  height: 0.75rem;
+  margin-top: var(--space-small);
+`
+export const SkeletonProfile = styled(SkeletonBox)`
+  width: 50px;
+  height: 50px;
+  border-radius: var(--border-radius-xlarge);
+`
+export const SkeletonGalleryImage = styled(SkeletonBox)`
+  width: 431px;
+  height: 287px;
+`

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -1,0 +1,28 @@
+interface PosterBoxProps {
+  title: string
+  imageUrl: string
+  date: string
+  flex?: boolean
+  onClick?: () => void
+}
+interface PosterBoxContainerProps {
+  title: string
+  imageUrl: string
+  date: string
+  flex?: boolean
+}
+interface MovieImageBoxProps {
+  src: string
+  alt: string
+  flex?: boolean
+}
+interface ContentBoxProps {
+  flex?: boolean
+}
+
+export type {
+  PosterBoxProps,
+  PosterBoxContainerProps,
+  MovieImageBoxProps,
+  ContentBoxProps
+}

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -4,6 +4,7 @@ interface PosterBoxProps {
   date: string
   flex?: boolean
   onClick?: () => void
+  isLoading?: boolean
 }
 interface PosterBoxContainerProps {
   title: string


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

공통컴포넌트(포스터박스, 스켈레톤) 제작

## 📋 작업 내용

- 포스터 박스, 스켈레톤UI 컴포넌트 제작


## 📸 스크린샷 (선택 사항)

![sample](https://github.com/user-attachments/assets/0483c5b7-5239-41b9-9d0f-bd25d59231b8)

## 📄 기타

1. 프로필 사진, 스틸 사진 및 포스터 박스에서 활용하는 스켈레톤 제작했습니다.
    import해서 활용하시면 됩니다.
2. 포스터박스 컴포넌트는 댓글 상세페이지에서 재활용하는 것을 고려하여 flex모드를 만들었습니다.
   이미지 크기 관련해서 우선 피그마의 댓글 상세페이지에 해당하는 크기로 제작하습니다.
3. 적극적인 피드백은 환영입니다(여..열심히 수정해볼게요..)
