### PR TITLE
[🎨 HTML&CSS] 다른 유저 프로필 클릭시 모달 구현

### DIFF
--- a/src/components/common-ui/modal/profile-modal/ProfileModal.styled.ts
+++ b/src/components/common-ui/modal/profile-modal/ProfileModal.styled.ts
@@ -1,0 +1,92 @@
+import styled from 'styled-components'
+import { IoMdClose } from 'react-icons/io'
+
+interface ProfileWrapperProps {
+  left: string
+  top: string
+}
+
+export const ProfileWrapper = styled.div<ProfileWrapperProps>`
+  width: 15%;
+  height: 18vh;
+  background-color: var(--color-profile-background);
+  border-radius: var(--border-radius-medium);
+  display: flex;
+  flex-direction: row;
+  position: absolute;
+  left: ${({ left }) => left};
+  top: ${({ top }) => top};
+  z-index: 1;
+  padding: var(--space-small);
+`
+
+export const ProfileImg = styled.div`
+  width: 30%;
+  height: 8vh;
+  border-radius: var(--border-radius-xlarge);
+  background-color: var(--color-white);
+  position: absolute;
+  top: 10%;
+  left: 2%;
+`
+export const ProfileContainer = styled.div`
+  width: 60%;
+  height: 90%;
+  position: absolute;
+  top: 20%;
+  left: 35%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`
+
+export const ProfileName = styled.div`
+  font-size: var(--font-large);
+  font-weight: 700;
+  color: var(--color-text-dark);
+  margin-bottom: 1vh;
+`
+export const ProfileContainerBox = styled.div`
+  width: 100%;
+  height: 40vh;
+  display: flex;
+  flex-direction: row;
+  gap: 10%;
+`
+
+export const ProfileBox = styled.div`
+  width: 45%;
+  height: 70%;
+  background-color: var(--color-white);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`
+
+export const ReviewCounter = styled.div`
+  color: var(--color-text-dark);
+  font-size: var(--font-large);
+  font-weight: 700;
+  cursor: pointer;
+`
+
+export const Bookmark = styled.div`
+  color: var(--color-text-dark);
+  font-size: var(--font-large);
+  font-weight: 700;
+  cursor: pointer;
+`
+
+export const subText = styled.div`
+  color: var(--color-text-gray);
+`
+export const CloseIcon = styled(IoMdClose)`
+  cursor: pointer;
+  width: 13%;
+  height: 5vh;
+  right: 0.1%;
+  position: absolute;
+  color: var(--color-black);
+`

--- a/src/components/common-ui/modal/profile-modal/ProfileModal.tsx
+++ b/src/components/common-ui/modal/profile-modal/ProfileModal.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import * as S from './ProfileModal.styled'
+import { Profile } from '@/components'
+interface ProfileModalProps {
+  onClose: () => void
+  position: { left: string; top: string }
+}
+
+export const modalPosition = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const button = event.currentTarget.getBoundingClientRect()
+  const offsetX = 60
+  const offsetY = -150
+  return {
+    left: button.left + offsetX + 'px',
+    top: button.top + offsetY + 'px'
+  }
+}
+
+export const ProfileModal: React.FC<ProfileModalProps> = ({
+  onClose,
+  position
+}) => {
+  const handleProfileClick = () => {}
+
+  return (
+    <S.ProfileWrapper
+      left={position.left}
+      top={position.top}>
+      <Profile
+        imageUrl="https://cdn.greenpostkorea.co.kr/news/photo/201609/67077_50854_art_1474594867.jpg"
+        altText="Profile"
+        onClick={handleProfileClick}
+        size="95px"
+      />
+      <S.ProfileContainer>
+        <S.ProfileName>민정</S.ProfileName>
+        <S.ProfileContainerBox>
+          <S.ProfileBox>
+            <S.ReviewCounter>193</S.ReviewCounter>
+            <S.subText>평가</S.subText>
+          </S.ProfileBox>
+          <S.ProfileBox>
+            <S.Bookmark>5</S.Bookmark>
+            <S.subText>즐겨찾기</S.subText>
+          </S.ProfileBox>
+        </S.ProfileContainerBox>
+      </S.ProfileContainer>
+      <S.CloseIcon onClick={onClose} />
+    </S.ProfileWrapper>
+  )
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

다른 유저 프로필 클릭시 모달 구현

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

프로필을 클릭시 해당 컴포넌트의 위치 값에 x값과 y값을 조정하여 모달의 위치를 출력하게 했습니다
그래서 프로필의 크기에 따라 모달의 위치 또한 변경되어야 합니다
임시 버튼을 만들어 테스트했는데 width와 height 값에 따라 모달의 위치가 달라질 수 있습니다.
이에 따라 프로필 클릭으로 실제 적용할 때 다시 값을 수정하겠습니다

## 📸 스크린샷 (선택 사항)

### Profile 컴포넌트 적용시

![Profile](https://github.com/user-attachments/assets/6e21efb7-a400-4a1d-9edf-ed6cde939e3a)


## 📄 기타

다른 곳에서 사용할 때 

1. `import { ProfileModal, modalPosition } from '@/components'; `
2. ```const [modalPositionState, setModalPositionState] = useState({ left: '0px', top: '0px' });`
const [isModalOpen, setIsModalOpen] = useState(false);```
3. ```const handleClick1 = (event: React.MouseEvent<HTMLButtonElement>) => {
    const position = modalPosition(event);
    setModalPositionState(position);
    setIsModalOpen(true);
  ```
 4.   ```const handleClose = () => {
    setIsModalOpen(false);
  };
  ```
5.       ```<button onClick={handleClick1}>Profile 1</button>
        {isModalOpen1 && (
          <ProfileModal
            onClose={handleClose1}
            position={{ top: modalPositionState.top, left: modalPositionState.left }}
          />
        )}```